### PR TITLE
Add bot configuration approval controls

### DIFF
--- a/admin/src/admin.js
+++ b/admin/src/admin.js
@@ -32,6 +32,7 @@ import { ServiceEditor, AppConfigEditor } from "./react-components/service-edito
 import { ServerAccess } from "./react-components/server-access";
 import { ContentCDN } from "./react-components/content-cdn";
 import { ImportContent } from "./react-components/import-content";
+import { BotConfigApprovals } from "./react-components/bot-config-approvals";
 import { AutoEndSessionDialog } from "./react-components/auto-end-session-dialog";
 import registerTelemetry from "hubs/src/telemetry";
 import { UnauthorizedPage } from "./react-components/unauthorized";
@@ -250,8 +251,9 @@ document.addEventListener("DOMContentLoaded", async () => {
   const importRoute = <Route exact path="/import" component={ImportContent} />;
   const accessRoute = <Route exact path="/server-access" component={ServerAccess} />;
   const cdnRoute = <Route exact path="/content-cdn" component={ContentCDN} />;
+  const botConfigApprovalsRoute = <Route exact path="/bot-config-approvals" component={BotConfigApprovals} />;
 
-  const customRoutes = [homeRoute, importRoute, accessRoute, cdnRoute];
+  const customRoutes = [homeRoute, importRoute, accessRoute, cdnRoute, botConfigApprovalsRoute];
 
   try {
     const appConfigSchema = schemaByCategories({

--- a/admin/src/react-components/admin-menu.js
+++ b/admin/src/react-components/admin-menu.js
@@ -15,6 +15,7 @@ import LibraryBooksIcon from "@material-ui/icons/LibraryBooks";
 import BackupIcon from "@material-ui/icons/Backup";
 import ViewIcon from "@material-ui/icons/ViewList";
 import SettingsIcon from "@material-ui/icons/Settings";
+import VerifiedUserIcon from "@material-ui/icons/VerifiedUser";
 import Collapse from "@material-ui/core/Collapse";
 import { getServiceDisplayName } from "../utils/ita";
 import configs from "../utils/configs";
@@ -125,6 +126,22 @@ class Menu extends Component {
       >
         {icon && <ListItemIcon className={this.props.classes.icon}>{icon}</ListItemIcon>}
         <ListItemText className={this.props.classes.text} primary={getResourceDisplayName(resource)} />
+      </ListItem>
+    );
+  }
+
+  renderBotApprovalLink() {
+    return (
+      <ListItem
+        className={classNames(this.props.classes.item, this.props.classes.nested)}
+        component={NavLink}
+        key="bot-config-approvals"
+        to="/bot-config-approvals"
+      >
+        <ListItemIcon className={this.props.classes.icon}>
+          <VerifiedUserIcon />
+        </ListItemIcon>
+        <ListItemText className={this.props.classes.text} primary="Aprobaciones de bots" />
       </ListItem>
     );
   }
@@ -251,6 +268,7 @@ class Menu extends Component {
                 </ListItemIcon>
                 <ListItemText className={this.props.classes.text} primary="App Settings" />
               </ListItem>
+              {this.renderBotApprovalLink()}
 
               {hasPaidFeature() && !isBrandingDisabled() && (
                 <>
@@ -344,6 +362,7 @@ class Menu extends Component {
                 </ListItemIcon>
                 <ListItemText className={this.props.classes.text} primary="App Settings" />
               </ListItem>
+              {this.renderBotApprovalLink()}
 
               <ListItem
                 className={classNames(this.props.classes.item, this.props.classes.nested)}

--- a/admin/src/react-components/bot-config-approvals.js
+++ b/admin/src/react-components/bot-config-approvals.js
@@ -1,0 +1,656 @@
+/* eslint-disable @calm/react-intl/missing-formatted-message */
+
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import PropTypes from "prop-types";
+import { AUTH_ERROR, Title } from "react-admin";
+import { withStyles } from "@material-ui/core/styles";
+import Button from "@material-ui/core/Button";
+import Card from "@material-ui/core/Card";
+import CardActions from "@material-ui/core/CardActions";
+import CardContent from "@material-ui/core/CardContent";
+import CardHeader from "@material-ui/core/CardHeader";
+import Chip from "@material-ui/core/Chip";
+import CircularProgress from "@material-ui/core/CircularProgress";
+import Dialog from "@material-ui/core/Dialog";
+import DialogActions from "@material-ui/core/DialogActions";
+import DialogContent from "@material-ui/core/DialogContent";
+import DialogContentText from "@material-ui/core/DialogContentText";
+import DialogTitle from "@material-ui/core/DialogTitle";
+import Typography from "@material-ui/core/Typography";
+
+import configs from "../utils/configs";
+import withCommonStyles from "../utils/with-common-styles";
+import {
+  BotConfigApprovalApiError,
+  botConfigApprovalContract,
+  createBotConfigApprovalClient
+} from "../utils/bot-config-approvals-api";
+
+const REASON_LABELS = Object.freeze({
+  admin_quarantine: "Cuarentena solicitada por administración",
+  bots_disabled: "Bots deshabilitados",
+  bots_removed: "Configuración de bots eliminada",
+  legacy_migration: "Configuración heredada puesta en cuarentena",
+  room_closed: "Sala cerrada",
+  unapproved_bot_config_change: "Configuración modificada sin aprobación"
+});
+
+const ENTRY_MODE_LABELS = Object.freeze({
+  allow: "Abierta",
+  deny: "Cerrada",
+  invite: "Solo con invitación"
+});
+
+const MOBILITY_LABELS = Object.freeze({
+  high: "Alta",
+  low: "Baja",
+  medium: "Media",
+  static: "Estática"
+});
+
+const ERROR_LABELS = Object.freeze({
+  approval_unavailable: "La decisión no está disponible temporalmente; no se modificó la aprobación.",
+  config_too_large: "El candidato supera el tamaño permitido y permanece en cuarentena.",
+  fingerprint_mismatch: "La configuración cambió mientras la revisabas. El inventario se recargó; revísala de nuevo.",
+  inactive_candidate: "El candidato está deshabilitado o no contiene bots activos y no se puede aprobar.",
+  invalid_candidate: "El candidato ya no es válido y permanece en cuarentena.",
+  invalid_config: "La configuración ya no es válida y permanece en cuarentena.",
+  invalid_request: "Reticulum rechazó la forma de la solicitud; no se tomó ninguna decisión.",
+  missing_auth_token: "La sesión de administración ya no está disponible.",
+  network_error: "No se pudo confirmar la respuesta. Se consultó de nuevo el estado durable sin repetir la acción.",
+  not_found: "La sala o su registro de aprobación ya no existe. El inventario se recargó.",
+  room_limit: "Se alcanzó el límite global de salas con bots; el candidato no fue aprobado.",
+  unavailable: "La decisión no está disponible temporalmente; no se modificó la aprobación."
+});
+
+const styles = withCommonStyles(theme => ({
+  page: {
+    alignSelf: "stretch",
+    width: "auto",
+    maxWidth: 1120,
+    boxSizing: "border-box"
+  },
+  headerRow: {
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "space-between",
+    flexWrap: "wrap",
+    gap: theme.spacing(2),
+    marginBottom: theme.spacing(2),
+    width: "100%"
+  },
+  notice: {
+    width: "100%",
+    boxSizing: "border-box",
+    borderRadius: 4,
+    padding: theme.spacing(2),
+    marginBottom: theme.spacing(2),
+    backgroundColor: "#eef3ff",
+    border: "1px solid #aabce8"
+  },
+  errorNotice: {
+    backgroundColor: "#fff1f1",
+    borderColor: "#b43b3b"
+  },
+  warningNotice: {
+    backgroundColor: "#fff8e1",
+    borderColor: "#b7791f"
+  },
+  progress: {
+    display: "flex",
+    alignItems: "center",
+    gap: theme.spacing(2),
+    padding: theme.spacing(3, 0)
+  },
+  cards: {
+    display: "grid",
+    gridTemplateColumns: "minmax(0, 1fr)",
+    gap: theme.spacing(2),
+    width: "100%"
+  },
+  card: {
+    width: "100%",
+    overflow: "hidden"
+  },
+  cardHeader: {
+    alignItems: "flex-start"
+  },
+  cardTitle: {
+    overflowWrap: "anywhere",
+    wordBreak: "break-word"
+  },
+  summaryGrid: {
+    display: "grid",
+    gridTemplateColumns: "repeat(auto-fit, minmax(160px, 1fr))",
+    gap: theme.spacing(1, 2),
+    margin: theme.spacing(2, 0)
+  },
+  definition: {
+    margin: 0,
+    minWidth: 0,
+    "& dt": {
+      fontWeight: 600,
+      marginTop: theme.spacing(1)
+    },
+    "& dd": {
+      margin: theme.spacing(0.5, 0, 0),
+      overflowWrap: "anywhere"
+    }
+  },
+  fingerprint: {
+    display: "block",
+    fontFamily: "monospace",
+    fontSize: "0.78rem",
+    overflowWrap: "anywhere",
+    wordBreak: "break-all"
+  },
+  actions: {
+    display: "flex",
+    flexWrap: "wrap",
+    gap: theme.spacing(1),
+    padding: theme.spacing(2)
+  },
+  dialogFingerprint: {
+    display: "block",
+    marginTop: theme.spacing(1),
+    padding: theme.spacing(1),
+    backgroundColor: "#f5f5f5",
+    fontFamily: "monospace",
+    fontSize: "0.78rem",
+    overflowWrap: "anywhere",
+    wordBreak: "break-all"
+  }
+}));
+
+function defaultClient() {
+  return createBotConfigApprovalClient({
+    fetchImpl: (...args) => window.fetch(...args),
+    getToken: () =>
+      window.APP &&
+      window.APP.store &&
+      window.APP.store.state &&
+      window.APP.store.state.credentials &&
+      window.APP.store.state.credentials.token,
+    buildUrl: path => (configs.RETICULUM_SERVER ? `https://${configs.RETICULUM_SERVER}${path}` : path)
+  });
+}
+
+async function defaultAuthErrorHandler(status) {
+  const authProvider = window.APP && window.APP.authProvider;
+  if (typeof authProvider === "function") {
+    try {
+      await authProvider(AUTH_ERROR, { status });
+    } catch {
+      // The existing auth provider rejects after initiating its redirect.
+    }
+  }
+}
+
+function isAbort(error) {
+  return error && error.name === "AbortError";
+}
+
+function errorText(error) {
+  if (error && (error.status === 401 || error.status === 403)) return "La sesión no tiene permisos de administración.";
+  if (error && ERROR_LABELS[error.code]) return ERROR_LABELS[error.code];
+  if (error instanceof BotConfigApprovalApiError && error.status === 502) {
+    return "Reticulum devolvió un contrato de aprobación inesperado. Las acciones quedan bloqueadas.";
+  }
+  return "No se pudo cargar un inventario completo y verificable. Las acciones quedan bloqueadas.";
+}
+
+function formatTimestamp(value) {
+  if (!value) return "—";
+  return new Intl.DateTimeFormat("es-ES", { dateStyle: "medium", timeStyle: "short" }).format(new Date(value));
+}
+
+function fingerprint(value) {
+  return value || "—";
+}
+
+function RedactedSummary({ classes, summary, title }) {
+  return (
+    <section>
+      <Typography variant="subtitle2" component="h3">
+        {title}
+      </Typography>
+      {summary ? (
+        <dl className={`${classes.definition} ${classes.summaryGrid}`}>
+          <div>
+            <dt>Habilitada</dt>
+            <dd>{summary.enabled ? "Sí" : "No"}</dd>
+          </div>
+          <div>
+            <dt>Número de bots</dt>
+            <dd>{summary.count}</dd>
+          </div>
+          <div>
+            <dt>Movilidad</dt>
+            <dd>{MOBILITY_LABELS[summary.mobility]}</dd>
+          </div>
+          <div>
+            <dt>Chat</dt>
+            <dd>{summary.chat_enabled ? "Sí" : "No"}</dd>
+          </div>
+          <div>
+            <dt>Prompt redactado</dt>
+            <dd>
+              {summary.prompt_present
+                ? `Presente (${summary.prompt_bytes} bytes, ${summary.prompt_codepoints} caracteres Unicode)`
+                : "No presente"}
+            </dd>
+          </div>
+        </dl>
+      ) : (
+        <Typography variant="body2">Sin configuración de bots.</Typography>
+      )}
+    </section>
+  );
+}
+
+RedactedSummary.propTypes = {
+  classes: PropTypes.object.isRequired,
+  summary: PropTypes.shape({
+    chat_enabled: PropTypes.bool.isRequired,
+    count: PropTypes.number.isRequired,
+    enabled: PropTypes.bool.isRequired,
+    mobility: PropTypes.string.isRequired,
+    prompt_bytes: PropTypes.number.isRequired,
+    prompt_codepoints: PropTypes.number.isRequired,
+    prompt_present: PropTypes.bool.isRequired
+  }),
+  title: PropTypes.string.isRequired
+};
+
+function durableDecisionMatches(decision, approvals) {
+  const row = approvals.find(approval => approval.hub_sid === decision.approval.hub_sid);
+  if (!row) return false;
+  if (decision.type === "quarantine") {
+    return row.state === "quarantined" && row.approved_config_fingerprint === null && !row.runtime_approved;
+  }
+  return (
+    row.state === "approved" &&
+    row.candidate_config_fingerprint === decision.expectedFingerprint &&
+    row.approved_config_fingerprint === decision.expectedFingerprint &&
+    row.current_config_fingerprint === decision.expectedFingerprint
+  );
+}
+
+export function BotConfigApprovalsComponent({ classes, apiClient, onAuthError }) {
+  const client = useMemo(() => apiClient || defaultClient(), [apiClient]);
+  const authErrorHandler = onAuthError || defaultAuthErrorHandler;
+  const mountedRef = useRef(false);
+  const loadAbortRef = useRef(null);
+  const actionAbortRef = useRef(null);
+  const loadEpochRef = useRef(0);
+  const [approvals, setApprovals] = useState([]);
+  const [inventoryComplete, setInventoryComplete] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [operation, setOperation] = useState(null);
+  const [decision, setDecision] = useState(null);
+  const [notice, setNotice] = useState(null);
+
+  const loadInventory = useCallback(
+    async ({ clearNotice = true } = {}) => {
+      if (loadAbortRef.current) loadAbortRef.current.abort();
+      const controller = new AbortController();
+      loadAbortRef.current = controller;
+      const epoch = ++loadEpochRef.current;
+
+      if (mountedRef.current) {
+        setLoading(true);
+        setInventoryComplete(false);
+        setApprovals([]);
+        if (clearNotice) setNotice(null);
+      }
+
+      try {
+        await client.assertCapability({ signal: controller.signal });
+        const completeInventory = await client.listAll({ signal: controller.signal });
+        if (!mountedRef.current || epoch !== loadEpochRef.current) return null;
+        setApprovals(completeInventory);
+        setInventoryComplete(true);
+        return completeInventory;
+      } catch (error) {
+        if (isAbort(error)) return null;
+        if (!mountedRef.current || epoch !== loadEpochRef.current) return null;
+        setApprovals([]);
+        setInventoryComplete(false);
+        setNotice({ kind: "error", text: errorText(error) });
+        if (error && (error.status === 401 || error.status === 403)) await authErrorHandler(error.status);
+        return null;
+      } finally {
+        if (mountedRef.current && epoch === loadEpochRef.current) setLoading(false);
+      }
+    },
+    [authErrorHandler, client]
+  );
+
+  useEffect(() => {
+    mountedRef.current = true;
+    loadInventory();
+    return () => {
+      mountedRef.current = false;
+      loadEpochRef.current += 1;
+      if (loadAbortRef.current) loadAbortRef.current.abort();
+      if (actionAbortRef.current) actionAbortRef.current.abort();
+    };
+  }, [loadInventory]);
+
+  const executeDecision = useCallback(async () => {
+    if (!decision || operation) return;
+    const capturedDecision = decision;
+    const controller = new AbortController();
+    actionAbortRef.current = controller;
+    setOperation({ hubSid: capturedDecision.approval.hub_sid, type: capturedDecision.type });
+    setNotice(null);
+
+    let actionError = null;
+    try {
+      if (capturedDecision.type === "approve") {
+        await client.approve(capturedDecision.approval.hub_sid, capturedDecision.expectedFingerprint, {
+          signal: controller.signal
+        });
+      } else {
+        await client.quarantine(capturedDecision.approval.hub_sid, { signal: controller.signal });
+      }
+    } catch (error) {
+      if (isAbort(error)) return;
+      if (error && (error.status === 401 || error.status === 403)) {
+        if (mountedRef.current) {
+          setApprovals([]);
+          setInventoryComplete(false);
+          setNotice({ kind: "error", text: errorText(error) });
+          setDecision(null);
+          setOperation(null);
+          actionAbortRef.current = null;
+        }
+        try {
+          await authErrorHandler(error.status);
+        } catch {
+          // Auth handlers may reject after initiating their redirect.
+        }
+        return;
+      }
+      actionError = error;
+    }
+
+    if (!mountedRef.current || controller.signal.aborted) return;
+    const durableInventory = await loadInventory({ clearNotice: false });
+    if (!mountedRef.current || controller.signal.aborted) return;
+
+    const durableMatch = durableInventory && durableDecisionMatches(capturedDecision, durableInventory);
+
+    if (!durableMatch && actionError) {
+      setNotice({ kind: "error", text: errorText(actionError) });
+    } else if (!durableMatch) {
+      setNotice({
+        kind: "error",
+        text: "Reticulum respondió, pero el inventario durable no confirma la decisión. No se repitió la acción."
+      });
+    } else if (capturedDecision.type === "approve") {
+      const row = durableInventory.find(item => item.hub_sid === capturedDecision.approval.hub_sid);
+      setNotice({
+        kind: row.runtime_approved ? "success" : "warning",
+        text: row.runtime_approved
+          ? "Candidato aprobado con coincidencia durable exacta. La readiness del runner se verifica por separado."
+          : "Candidato aprobado de forma durable, pero la sala no está habilitada para runtime."
+      });
+    } else {
+      setNotice({
+        kind: "warning",
+        text: "Cuarentena durable confirmada. La parada inmediata del runner se verifica por separado."
+      });
+    }
+
+    setDecision(null);
+    setOperation(null);
+    actionAbortRef.current = null;
+  }, [authErrorHandler, client, decision, loadInventory, operation]);
+
+  const openApprove = approval => {
+    setDecision({
+      approval,
+      expectedFingerprint: approval.candidate_config_fingerprint,
+      type: "approve"
+    });
+  };
+
+  const openQuarantine = approval => {
+    setDecision({ approval, expectedFingerprint: null, type: "quarantine" });
+  };
+
+  const busy = loading || operation !== null;
+
+  return (
+    <div className={`${classes.container} ${classes.page}`} aria-busy={busy}>
+      <div className={classes.headerRow}>
+        <div>
+          <Typography variant="h5" component="h1">
+            Aprobaciones de configuraciones de bots
+          </Typography>
+          <Typography variant="body2">
+            Inventario redactado. Nunca muestra el prompt ni el JSON de configuración.
+          </Typography>
+        </div>
+        <Button variant="outlined" onClick={() => loadInventory()} disabled={busy}>
+          Actualizar inventario
+        </Button>
+      </div>
+
+      <div className={`${classes.notice} ${classes.warningNotice}`} role="note">
+        Una aprobación durable no demuestra que el runner esté listo. Una cuarentena durable tampoco garantiza parada
+        inmediata; ambos estados se verifican operativamente por separado.
+      </div>
+
+      {notice && (
+        <div
+          className={`${classes.notice} ${notice.kind === "error" ? classes.errorNotice : ""} ${
+            notice.kind === "warning" ? classes.warningNotice : ""
+          }`}
+          role={notice.kind === "error" ? "alert" : "status"}
+        >
+          {notice.text}
+        </div>
+      )}
+
+      {loading && (
+        <div className={classes.progress} role="status">
+          <CircularProgress size={28} />
+          <span>Cargando y verificando el inventario completo…</span>
+        </div>
+      )}
+
+      {!loading && inventoryComplete && approvals.length === 0 && (
+        <Typography role="status">No existen registros de aprobación de bots.</Typography>
+      )}
+
+      {!loading && inventoryComplete && approvals.length > 0 && (
+        <>
+          <Typography variant="body2" gutterBottom role="status">
+            Inventario completo: {approvals.length} {approvals.length === 1 ? "registro" : "registros"}.
+          </Typography>
+          <section className={classes.cards} aria-label="Inventario de aprobaciones de bots">
+            {approvals.map(approval => {
+              const summary = approval.candidate_summary;
+              const candidateIsActive = summary.enabled && summary.count > 0;
+              const canApprove =
+                !busy &&
+                approval.state === "quarantined" &&
+                candidateIsActive &&
+                botConfigApprovalContract.FINGERPRINT_PATTERN.test(approval.candidate_config_fingerprint || "");
+              const canQuarantine = !busy && approval.state === "approved";
+              const headingId = `bot-config-approval-${approval.hub_sid}`;
+              return (
+                <Card aria-labelledby={headingId} className={classes.card} component="article" key={approval.hub_sid}>
+                  <CardHeader
+                    className={classes.cardHeader}
+                    title={approval.hub_sid}
+                    titleTypographyProps={{ className: classes.cardTitle, component: "h2", id: headingId }}
+                    subheader={`Actualizado: ${formatTimestamp(approval.updated_at)}`}
+                    action={
+                      <Chip
+                        color={approval.state === "approved" ? "primary" : "default"}
+                        label={approval.state === "approved" ? "Aprobada" : "En cuarentena"}
+                      />
+                    }
+                  />
+                  <CardContent>
+                    <Typography variant="body2" color="textSecondary">
+                      Coincidencia durable válida: {approval.runtime_approved ? "Sí" : "No"}
+                    </Typography>
+                    <Typography variant="body2" color="textSecondary">
+                      Propietario: {approval.created_by_account_id ? `cuenta ${approval.created_by_account_id}` : "—"} ·
+                      Acceso: {ENTRY_MODE_LABELS[approval.entry_mode]}
+                    </Typography>
+                    {approval.state === "quarantined" &&
+                      approval.candidate_config_fingerprint !== approval.current_config_fingerprint && (
+                        <Typography variant="body2">
+                          El candidato preservado difiere de la configuración actual deshabilitada. Aprobarlo lo vuelve
+                          a aplicar.
+                        </Typography>
+                      )}
+                    {approval.state === "quarantined" && !approval.candidate_config_fingerprint && (
+                      <Typography variant="body2">
+                        El candidato heredado no tiene un fingerprint verificable. Solo puede permanecer en cuarentena;
+                        la aprobación está bloqueada.
+                      </Typography>
+                    )}
+
+                    <RedactedSummary classes={classes} summary={summary} title="Candidato preservado" />
+                    <RedactedSummary
+                      classes={classes}
+                      summary={approval.current_summary}
+                      title="Configuración actual"
+                    />
+
+                    <dl className={classes.definition}>
+                      <dt>Fingerprint candidato</dt>
+                      <dd>
+                        <code className={classes.fingerprint}>
+                          {fingerprint(approval.candidate_config_fingerprint)}
+                        </code>
+                      </dd>
+                      <dt>Fingerprint aprobado</dt>
+                      <dd>
+                        <code className={classes.fingerprint}>{fingerprint(approval.approved_config_fingerprint)}</code>
+                      </dd>
+                      <dt>Fingerprint actual</dt>
+                      <dd>
+                        <code className={classes.fingerprint}>{fingerprint(approval.current_config_fingerprint)}</code>
+                      </dd>
+                      <dt>Última aprobación</dt>
+                      <dd>
+                        {approval.approved_by_account_id
+                          ? `Cuenta ${approval.approved_by_account_id}, ${formatTimestamp(approval.approved_at)}`
+                          : "—"}
+                      </dd>
+                      <dt>Última cuarentena</dt>
+                      <dd>
+                        {approval.last_quarantined_at
+                          ? `${REASON_LABELS[approval.last_quarantine_reason] || approval.last_quarantine_reason}; ${
+                              approval.last_quarantined_by_account_id
+                                ? `cuenta ${approval.last_quarantined_by_account_id}`
+                                : approval.last_quarantine_reason === "legacy_migration"
+                                  ? "migración automática"
+                                  : "acción automática"
+                            }, ${formatTimestamp(approval.last_quarantined_at)}`
+                          : "—"}
+                      </dd>
+                    </dl>
+                  </CardContent>
+                  <CardActions className={classes.actions}>
+                    <Button
+                      color="primary"
+                      variant="contained"
+                      disabled={!canApprove}
+                      onClick={() => openApprove(approval)}
+                      aria-label={`Aprobar candidato de ${approval.hub_sid}`}
+                    >
+                      Aprobar candidato
+                    </Button>
+                    <Button
+                      variant="outlined"
+                      disabled={!canQuarantine}
+                      onClick={() => openQuarantine(approval)}
+                      aria-label={`Poner ${approval.hub_sid} en cuarentena`}
+                    >
+                      Poner en cuarentena
+                    </Button>
+                  </CardActions>
+                </Card>
+              );
+            })}
+          </section>
+        </>
+      )}
+
+      <Dialog
+        open={decision !== null}
+        onClose={() => {
+          if (!operation) setDecision(null);
+        }}
+        aria-labelledby="bot-config-decision-title"
+      >
+        {decision && (
+          <>
+            <DialogTitle id="bot-config-decision-title">
+              {decision.type === "approve" ? "Confirmar aprobación" : "Confirmar cuarentena"}
+            </DialogTitle>
+            <DialogContent>
+              <DialogContentText component="div">
+                {decision.type === "approve" ? (
+                  <>
+                    Esta acción vuelve a escribir el candidato preservado de <b>{decision.approval.hub_sid}</b> y puede
+                    habilitar hasta {decision.approval.candidate_summary.count} bots cuando la sala esté abierta. No es
+                    solo un cambio de etiqueta.
+                    <code className={classes.dialogFingerprint}>{decision.expectedFingerprint}</code>
+                  </>
+                ) : (
+                  <>
+                    Esta acción deshabilita los bots de <b>{decision.approval.hub_sid}</b> y conserva el candidato para
+                    una revisión posterior. La parada del runner se comprueba por separado.
+                  </>
+                )}
+              </DialogContentText>
+            </DialogContent>
+            <DialogActions>
+              <Button onClick={() => setDecision(null)} disabled={operation !== null}>
+                Cancelar
+              </Button>
+              <Button color="primary" variant="contained" onClick={executeDecision} disabled={operation !== null}>
+                {operation
+                  ? "Aplicando…"
+                  : decision.type === "approve"
+                    ? "Aprobar este fingerprint"
+                    : "Confirmar cuarentena"}
+              </Button>
+            </DialogActions>
+          </>
+        )}
+      </Dialog>
+    </div>
+  );
+}
+
+BotConfigApprovalsComponent.propTypes = {
+  apiClient: PropTypes.shape({
+    approve: PropTypes.func.isRequired,
+    assertCapability: PropTypes.func.isRequired,
+    listAll: PropTypes.func.isRequired,
+    quarantine: PropTypes.func.isRequired
+  }),
+  classes: PropTypes.object.isRequired,
+  onAuthError: PropTypes.func
+};
+
+const StyledBotConfigApprovals = withStyles(styles)(BotConfigApprovalsComponent);
+
+export function BotConfigApprovals(props) {
+  return (
+    <>
+      <Title title="Aprobaciones de bots" />
+      <StyledBotConfigApprovals {...props} />
+    </>
+  );
+}

--- a/admin/src/utils/bot-config-approvals-api.js
+++ b/admin/src/utils/bot-config-approvals-api.js
@@ -1,0 +1,416 @@
+const APPROVAL_PROTOCOL = 1;
+const PAGE_SIZE = 100;
+const MAX_PAGES = 100;
+const MAX_RESPONSE_BYTES = 1024 * 1024;
+const FINGERPRINT_PATTERN = /^v1:[0-9a-f]{64}$/;
+const CURSOR_PATTERN = /^(?:0|[1-9][0-9]*)$/;
+const HUB_SID_PATTERN = /^[A-Za-z0-9_-]{1,128}$/;
+const UTC_TIMESTAMP_PATTERN = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{1,6})?Z$/;
+
+const APPROVAL_KEYS = [
+  "approved_at",
+  "approved_by_account_id",
+  "approved_config_fingerprint",
+  "candidate_config_fingerprint",
+  "candidate_summary",
+  "created_by_account_id",
+  "current_config_fingerprint",
+  "current_summary",
+  "entry_mode",
+  "hub_sid",
+  "last_quarantine_reason",
+  "last_quarantined_at",
+  "last_quarantined_by_account_id",
+  "runtime_approved",
+  "state",
+  "updated_at"
+];
+
+const SUMMARY_KEYS = [
+  "chat_enabled",
+  "count",
+  "enabled",
+  "mobility",
+  "prompt_bytes",
+  "prompt_codepoints",
+  "prompt_present"
+];
+const QUARANTINE_REASONS = new Set([
+  "admin_quarantine",
+  "bots_disabled",
+  "bots_removed",
+  "legacy_migration",
+  "room_closed",
+  "unapproved_bot_config_change"
+]);
+const API_ERROR_CODES = new Set([
+  "approval_unavailable",
+  "config_too_large",
+  "fingerprint_mismatch",
+  "forbidden",
+  "inactive_candidate",
+  "invalid_candidate",
+  "invalid_config",
+  "invalid_request",
+  "not_found",
+  "room_limit",
+  "unavailable"
+]);
+
+export class BotConfigApprovalApiError extends Error {
+  constructor(code, { status = 0, ambiguous = false, cause } = {}) {
+    super(code);
+    this.name = "BotConfigApprovalApiError";
+    this.code = code;
+    this.status = status;
+    this.ambiguous = ambiguous;
+    if (cause) this.cause = cause;
+  }
+}
+
+function contractError(code) {
+  return new BotConfigApprovalApiError(code, { status: 502 });
+}
+
+function exactKeys(value, expected) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  const actual = Object.keys(value).sort();
+  const wanted = [...expected].sort();
+  return actual.length === wanted.length && actual.every((key, index) => key === wanted[index]);
+}
+
+function isTimestamp(value, nullable = true) {
+  if (value === null) return nullable;
+  return (
+    typeof value === "string" &&
+    UTC_TIMESTAMP_PATTERN.test(value) &&
+    value.length <= 64 &&
+    Number.isFinite(Date.parse(value))
+  );
+}
+
+function isAccountId(value, nullable = true) {
+  if (value === null) return nullable;
+  return Number.isSafeInteger(value) && value > 0;
+}
+
+function isFingerprint(value, nullable = true) {
+  if (value === null) return nullable;
+  return typeof value === "string" && FINGERPRINT_PATTERN.test(value);
+}
+
+function validateSummary(summary, { nullable = false } = {}) {
+  if (summary === null && nullable) return null;
+  if (!exactKeys(summary, SUMMARY_KEYS)) throw contractError("invalid_candidate_summary");
+  if (typeof summary.enabled !== "boolean" || typeof summary.chat_enabled !== "boolean") {
+    throw contractError("invalid_candidate_summary");
+  }
+  if (!Number.isSafeInteger(summary.count) || summary.count < 0 || summary.count > 10) {
+    throw contractError("invalid_candidate_summary");
+  }
+  if (!["static", "low", "medium", "high"].includes(summary.mobility)) {
+    throw contractError("invalid_candidate_summary");
+  }
+  if (typeof summary.prompt_present !== "boolean") throw contractError("invalid_candidate_summary");
+  if (!Number.isSafeInteger(summary.prompt_bytes) || summary.prompt_bytes < 0) {
+    throw contractError("invalid_candidate_summary");
+  }
+  if (!Number.isSafeInteger(summary.prompt_codepoints) || summary.prompt_codepoints < 0) {
+    throw contractError("invalid_candidate_summary");
+  }
+  if (
+    summary.prompt_codepoints > summary.prompt_bytes ||
+    summary.prompt_present !== summary.prompt_bytes > 0 ||
+    summary.prompt_present !== summary.prompt_codepoints > 0
+  ) {
+    throw contractError("invalid_candidate_summary");
+  }
+  return Object.freeze({ ...summary });
+}
+
+export function validateApprovalEntry(value) {
+  if (!exactKeys(value, APPROVAL_KEYS)) throw contractError("invalid_approval_entry");
+  if (typeof value.hub_sid !== "string" || !HUB_SID_PATTERN.test(value.hub_sid)) {
+    throw contractError("invalid_hub_sid");
+  }
+  if (!["approved", "quarantined"].includes(value.state)) throw contractError("invalid_approval_state");
+  if (typeof value.runtime_approved !== "boolean") throw contractError("invalid_runtime_approval");
+  if (!isFingerprint(value.candidate_config_fingerprint)) throw contractError("invalid_candidate_fingerprint");
+  if (!isFingerprint(value.approved_config_fingerprint)) throw contractError("invalid_approved_fingerprint");
+  if (!isFingerprint(value.current_config_fingerprint)) throw contractError("invalid_current_fingerprint");
+  if (
+    !isAccountId(value.created_by_account_id) ||
+    !isAccountId(value.approved_by_account_id) ||
+    !isAccountId(value.last_quarantined_by_account_id)
+  ) {
+    throw contractError("invalid_actor_id");
+  }
+  if (!["allow", "invite", "deny"].includes(value.entry_mode)) throw contractError("invalid_entry_mode");
+  if (
+    !isTimestamp(value.approved_at) ||
+    !isTimestamp(value.last_quarantined_at) ||
+    !isTimestamp(value.updated_at, false)
+  ) {
+    throw contractError("invalid_audit_timestamp");
+  }
+  if (
+    value.last_quarantine_reason !== null &&
+    (typeof value.last_quarantine_reason !== "string" || !QUARANTINE_REASONS.has(value.last_quarantine_reason))
+  ) {
+    throw contractError("invalid_quarantine_reason");
+  }
+
+  const summary = validateSummary(value.candidate_summary);
+  const currentSummary = validateSummary(value.current_summary, { nullable: true });
+  const candidate = value.candidate_config_fingerprint;
+  const approved = value.approved_config_fingerprint;
+  const current = value.current_config_fingerprint;
+
+  if (currentSummary === null && current !== null) throw contractError("contradictory_current_summary");
+  if (
+    (value.last_quarantine_reason === null) !== (value.last_quarantined_at === null) ||
+    (value.last_quarantined_by_account_id !== null && value.last_quarantined_at === null)
+  ) {
+    throw contractError("contradictory_quarantine_audit");
+  }
+
+  if (value.state === "approved") {
+    if (!candidate || !approved || !current || !currentSummary || candidate !== approved || approved !== current) {
+      throw contractError("contradictory_approved_state");
+    }
+    if (!value.approved_by_account_id || !value.approved_at) throw contractError("missing_approval_audit");
+  } else {
+    if (approved !== null || value.approved_by_account_id !== null || value.approved_at !== null) {
+      throw contractError("contradictory_quarantine_state");
+    }
+    if (!value.last_quarantine_reason || !value.last_quarantined_at) {
+      throw contractError("missing_quarantine_audit");
+    }
+    if (value.runtime_approved) throw contractError("contradictory_runtime_state");
+  }
+
+  if (value.runtime_approved && (value.state !== "approved" || approved !== current)) {
+    throw contractError("contradictory_runtime_state");
+  }
+
+  return Object.freeze({ ...value, candidate_summary: summary, current_summary: currentSummary });
+}
+
+export function validateCapabilityResponse(value) {
+  const capability = value && value.bot_config_approval;
+  if (
+    !exactKeys(capability, ["legacy_default", "protocol", "runtime_match"]) ||
+    capability.protocol !== APPROVAL_PROTOCOL ||
+    capability.legacy_default !== "quarantined" ||
+    capability.runtime_match !== "exact_jsonb"
+  ) {
+    throw contractError("unsupported_bot_config_approval_capability");
+  }
+  return Object.freeze({ ...capability });
+}
+
+export function validateInventoryPage(value) {
+  if (!exactKeys(value, ["approvals", "next_cursor", "protocol"])) {
+    throw contractError("invalid_inventory_response");
+  }
+  if (value.protocol !== APPROVAL_PROTOCOL || !Array.isArray(value.approvals) || value.approvals.length > PAGE_SIZE) {
+    throw contractError("invalid_inventory_response");
+  }
+  if (
+    value.next_cursor !== null &&
+    (typeof value.next_cursor !== "string" || !CURSOR_PATTERN.test(value.next_cursor))
+  ) {
+    throw contractError("invalid_inventory_cursor");
+  }
+  return Object.freeze({
+    protocol: value.protocol,
+    approvals: Object.freeze(value.approvals.map(validateApprovalEntry)),
+    next_cursor: value.next_cursor
+  });
+}
+
+function utf8ByteLength(value) {
+  return new TextEncoder().encode(value).length;
+}
+
+function hasNoStore(headers) {
+  const value = headers && headers.get && headers.get("cache-control");
+  return (
+    typeof value === "string" &&
+    value
+      .toLowerCase()
+      .split(",")
+      .some(token => token.trim() === "no-store")
+  );
+}
+
+function hasJsonContentType(headers) {
+  const value = headers && headers.get && headers.get("content-type");
+  return typeof value === "string" && /^application\/json(?:\s*;|$)/i.test(value.trim());
+}
+
+async function parseJsonResponse(response, { ambiguous = false } = {}) {
+  if (!response || typeof response.status !== "number") throw contractError("invalid_http_response");
+  if (!hasNoStore(response.headers)) {
+    throw new BotConfigApprovalApiError("missing_no_store", { status: response.status });
+  }
+  if (!hasJsonContentType(response.headers)) {
+    throw new BotConfigApprovalApiError("invalid_content_type", { status: response.status });
+  }
+
+  let text;
+  try {
+    text = await response.text();
+  } catch (error) {
+    if (error && error.name === "AbortError") throw error;
+    throw new BotConfigApprovalApiError("network_error", {
+      status: response.status,
+      ambiguous,
+      cause: error
+    });
+  }
+  if (utf8ByteLength(text) > MAX_RESPONSE_BYTES) throw contractError("response_too_large");
+
+  let json;
+  try {
+    json = JSON.parse(text);
+  } catch {
+    throw contractError("invalid_json");
+  }
+
+  if (!response.ok) {
+    const code =
+      exactKeys(json, ["error"]) && typeof json.error === "string" && API_ERROR_CODES.has(json.error)
+        ? json.error
+        : "unexpected_api_error";
+    throw new BotConfigApprovalApiError(code, { status: response.status });
+  }
+  return json;
+}
+
+function validateActionResponse(value, expectedStatus, hubSid) {
+  if (!exactKeys(value, ["hub_sid", "status"]) || value.status !== expectedStatus || value.hub_sid !== hubSid) {
+    throw contractError("invalid_action_response");
+  }
+  return Object.freeze({ ...value });
+}
+
+function assertSignal(signal) {
+  if (signal !== undefined && (!signal || typeof signal.aborted !== "boolean")) {
+    throw new TypeError("signal must be an AbortSignal");
+  }
+}
+
+function compareDecimalStrings(left, right) {
+  if (left.length !== right.length) return left.length < right.length ? -1 : 1;
+  if (left === right) return 0;
+  return left < right ? -1 : 1;
+}
+
+export function createBotConfigApprovalClient({ fetchImpl, getToken, buildUrl }) {
+  if (typeof fetchImpl !== "function" || typeof getToken !== "function" || typeof buildUrl !== "function") {
+    throw new TypeError("fetchImpl, getToken and buildUrl are required");
+  }
+
+  async function request(path, { method = "GET", body, signal } = {}) {
+    assertSignal(signal);
+    const token = getToken();
+    if (typeof token !== "string" || token.length === 0) {
+      throw new BotConfigApprovalApiError("missing_auth_token", { status: 401 });
+    }
+
+    const headers = new Headers({
+      Accept: "application/json",
+      Authorization: `Bearer ${token}`
+    });
+    const options = {
+      cache: "no-store",
+      credentials: "same-origin",
+      headers,
+      method,
+      redirect: "error",
+      referrerPolicy: "same-origin",
+      signal
+    };
+    if (body !== undefined) {
+      headers.set("Content-Type", "application/json");
+      options.body = JSON.stringify(body);
+    }
+
+    let response;
+    try {
+      response = await fetchImpl(buildUrl(path), options);
+    } catch (error) {
+      if (error && error.name === "AbortError") throw error;
+      throw new BotConfigApprovalApiError("network_error", { ambiguous: method !== "GET", cause: error });
+    }
+    return parseJsonResponse(response, { ambiguous: method !== "GET" });
+  }
+
+  return Object.freeze({
+    async assertCapability({ signal } = {}) {
+      return validateCapabilityResponse(await request("/health/capabilities", { signal }));
+    },
+
+    async listAll({ signal } = {}) {
+      const approvals = [];
+      const seenHubSids = new Set();
+      const seenCursors = new Set();
+      let cursor = null;
+
+      for (let pageNumber = 0; pageNumber < MAX_PAGES; pageNumber += 1) {
+        const query = new URLSearchParams({ limit: String(PAGE_SIZE) });
+        if (cursor !== null) query.set("cursor", cursor);
+        const page = validateInventoryPage(await request(`/api/v1/bot_config_approvals?${query}`, { signal }));
+
+        for (const approval of page.approvals) {
+          if (seenHubSids.has(approval.hub_sid)) throw contractError("duplicate_inventory_hub");
+          seenHubSids.add(approval.hub_sid);
+          approvals.push(approval);
+        }
+
+        if (page.next_cursor === null) return Object.freeze([...approvals]);
+        if (seenCursors.has(page.next_cursor) || page.next_cursor === cursor) {
+          throw contractError("repeated_inventory_cursor");
+        }
+        if (cursor !== null && compareDecimalStrings(page.next_cursor, cursor) <= 0) {
+          throw contractError("non_increasing_inventory_cursor");
+        }
+        seenCursors.add(page.next_cursor);
+        cursor = page.next_cursor;
+      }
+
+      throw contractError("inventory_page_limit_exceeded");
+    },
+
+    async approve(hubSid, expectedFingerprint, { signal } = {}) {
+      if (typeof hubSid !== "string" || !HUB_SID_PATTERN.test(hubSid)) throw contractError("invalid_hub_sid");
+      if (typeof expectedFingerprint !== "string" || !FINGERPRINT_PATTERN.test(expectedFingerprint)) {
+        throw contractError("invalid_candidate_fingerprint");
+      }
+      const response = await request(`/api/v1/bot_config_approvals/${encodeURIComponent(hubSid)}/approve`, {
+        method: "POST",
+        body: { expected_config_fingerprint: expectedFingerprint },
+        signal
+      });
+      return validateActionResponse(response, "approved", hubSid);
+    },
+
+    async quarantine(hubSid, { signal } = {}) {
+      if (typeof hubSid !== "string" || !HUB_SID_PATTERN.test(hubSid)) throw contractError("invalid_hub_sid");
+      const response = await request(`/api/v1/bot_config_approvals/${encodeURIComponent(hubSid)}/quarantine`, {
+        method: "POST",
+        body: {},
+        signal
+      });
+      return validateActionResponse(response, "quarantined", hubSid);
+    }
+  });
+}
+
+export const botConfigApprovalContract = Object.freeze({
+  APPROVAL_PROTOCOL,
+  FINGERPRINT_PATTERN,
+  MAX_PAGES,
+  PAGE_SIZE
+});

--- a/test/unit/admin/bot-config-approvals-api.test.js
+++ b/test/unit/admin/bot-config-approvals-api.test.js
@@ -1,0 +1,323 @@
+import test from "ava";
+
+import {
+  BotConfigApprovalApiError,
+  createBotConfigApprovalClient,
+  validateApprovalEntry,
+  validateCapabilityResponse,
+  validateInventoryPage
+} from "../../../admin/src/utils/bot-config-approvals-api";
+
+const FINGERPRINT_A = `v1:${"a".repeat(64)}`;
+const FINGERPRINT_B = `v1:${"b".repeat(64)}`;
+
+const BACKEND_CONTRACT_ENTRY = Object.freeze({
+  approved_at: null,
+  approved_by_account_id: null,
+  approved_config_fingerprint: null,
+  candidate_config_fingerprint: FINGERPRINT_A,
+  candidate_summary: {
+    chat_enabled: true,
+    count: 2,
+    enabled: true,
+    mobility: "low",
+    prompt_bytes: 41,
+    prompt_codepoints: 37,
+    prompt_present: true
+  },
+  created_by_account_id: 7,
+  current_config_fingerprint: FINGERPRINT_B,
+  current_summary: {
+    chat_enabled: true,
+    count: 2,
+    enabled: false,
+    mobility: "low",
+    prompt_bytes: 41,
+    prompt_codepoints: 37,
+    prompt_present: true
+  },
+  entry_mode: "allow",
+  hub_sid: "room-a",
+  last_quarantine_reason: "legacy_migration",
+  last_quarantined_at: "2026-07-18T10:00:00.000000Z",
+  last_quarantined_by_account_id: null,
+  runtime_approved: false,
+  state: "quarantined",
+  updated_at: "2026-07-18T10:00:00.000000Z"
+});
+
+function approval(overrides = {}) {
+  return {
+    ...BACKEND_CONTRACT_ENTRY,
+    candidate_summary: { ...BACKEND_CONTRACT_ENTRY.candidate_summary },
+    current_summary: { ...BACKEND_CONTRACT_ENTRY.current_summary },
+    ...overrides
+  };
+}
+
+function approved(overrides = {}) {
+  return approval({
+    approved_at: "2026-07-18T11:00:00.000000Z",
+    approved_by_account_id: 12,
+    approved_config_fingerprint: FINGERPRINT_A,
+    current_config_fingerprint: FINGERPRINT_A,
+    current_summary: { ...BACKEND_CONTRACT_ENTRY.candidate_summary },
+    runtime_approved: true,
+    state: "approved",
+    ...overrides
+  });
+}
+
+function response(body, { status = 200, cacheControl = "private, no-store", contentType = "application/json" } = {}) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: {
+      "cache-control": cacheControl,
+      "content-type": contentType
+    }
+  });
+}
+
+function capability() {
+  return {
+    bot_config_approval: {
+      legacy_default: "quarantined",
+      protocol: 1,
+      runtime_match: "exact_jsonb"
+    },
+    waypoint_reservation: { protocol: 2 }
+  };
+}
+
+function createClient(fetchImpl) {
+  return createBotConfigApprovalClient({
+    fetchImpl,
+    getToken: () => "admin-token",
+    buildUrl: path => `https://reticulum.test${path}`
+  });
+}
+
+test("authenticated requests are no-store, redirect-safe and traverse the complete cursor inventory", async t => {
+  const requests = [];
+  const fetchImpl = async (url, options) => {
+    requests.push({ url, options });
+    if (url.endsWith("/health/capabilities")) return response(capability());
+    if (url.includes("cursor=10")) {
+      return response({ approvals: [approved({ hub_sid: "room-b" })], next_cursor: null, protocol: 1 });
+    }
+    return response({ approvals: [approval()], next_cursor: "10", protocol: 1 });
+  };
+  const client = createClient(fetchImpl);
+
+  await client.assertCapability();
+  const inventory = await client.listAll();
+
+  t.deepEqual(
+    inventory.map(row => row.hub_sid),
+    ["room-a", "room-b"]
+  );
+  t.is(requests.length, 3);
+  for (const { options } of requests) {
+    t.is(options.cache, "no-store");
+    t.is(options.credentials, "same-origin");
+    t.is(options.redirect, "error");
+    t.is(options.referrerPolicy, "same-origin");
+    t.is(options.headers.get("accept"), "application/json");
+    t.is(options.headers.get("authorization"), "Bearer admin-token");
+  }
+  t.true(requests[1].url.includes("limit=100"));
+  t.false(requests[1].url.includes("cursor="));
+  t.true(requests[2].url.includes("cursor=10"));
+});
+
+test("approve and quarantine emit only their closed protocol bodies and never retry", async t => {
+  const requests = [];
+  const client = createClient(async (url, options) => {
+    requests.push({ url, options });
+    const body = JSON.parse(options.body);
+    return response({
+      hub_sid: "room-a",
+      status: Object.prototype.hasOwnProperty.call(body, "expected_config_fingerprint") ? "approved" : "quarantined"
+    });
+  });
+
+  await client.approve("room-a", FINGERPRINT_A);
+  await client.quarantine("room-a");
+
+  t.is(requests.length, 2);
+  t.deepEqual(JSON.parse(requests[0].options.body), { expected_config_fingerprint: FINGERPRINT_A });
+  t.deepEqual(JSON.parse(requests[1].options.body), {});
+  t.is(requests[0].options.method, "POST");
+  t.is(requests[0].options.headers.get("content-type"), "application/json");
+});
+
+test("a transport failure is ambiguous for POST and is attempted exactly once", async t => {
+  let calls = 0;
+  const client = createClient(async () => {
+    calls += 1;
+    throw new TypeError("connection lost");
+  });
+
+  const error = await t.throwsAsync(() => client.approve("room-a", FINGERPRINT_A), {
+    instanceOf: BotConfigApprovalApiError,
+    message: "network_error"
+  });
+  t.true(error.ambiguous);
+  t.is(calls, 1);
+});
+
+test("a response body stream failure remains an ambiguous one-shot POST", async t => {
+  let calls = 0;
+  const client = createClient(async () => {
+    calls += 1;
+    return {
+      headers: new Headers({
+        "cache-control": "no-store",
+        "content-type": "application/json"
+      }),
+      ok: true,
+      status: 200,
+      text: async () => {
+        throw new TypeError("response stream reset");
+      }
+    };
+  });
+
+  const error = await t.throwsAsync(() => client.approve("room-a", FINGERPRINT_A), {
+    instanceOf: BotConfigApprovalApiError,
+    message: "network_error"
+  });
+  t.true(error.ambiguous);
+  t.is(error.status, 200);
+  t.is(calls, 1);
+});
+
+test("HTTP errors preserve the closed code and status without retry", async t => {
+  let calls = 0;
+  const client = createClient(async () => {
+    calls += 1;
+    return response({ error: "fingerprint_mismatch" }, { status: 409 });
+  });
+
+  const error = await t.throwsAsync(() => client.approve("room-a", FINGERPRINT_A), {
+    instanceOf: BotConfigApprovalApiError,
+    message: "fingerprint_mismatch"
+  });
+  t.is(error.status, 409);
+  t.false(error.ambiguous);
+  t.is(calls, 1);
+});
+
+test("missing no-store and non-JSON responses fail closed while retaining auth status", async t => {
+  const missingNoStore = createClient(async () => response(capability(), { cacheControl: "private" }));
+  const cacheError = await t.throwsAsync(() => missingNoStore.assertCapability(), {
+    instanceOf: BotConfigApprovalApiError,
+    message: "missing_no_store"
+  });
+  t.is(cacheError.status, 200);
+
+  const nonJson401 = createClient(async () => response({}, { status: 401, contentType: "text/plain" }));
+  const authError = await t.throwsAsync(() => nonJson401.assertCapability(), {
+    instanceOf: BotConfigApprovalApiError,
+    message: "invalid_content_type"
+  });
+  t.is(authError.status, 401);
+});
+
+test("the exact backend contract accepts legacy redaction but rejects extra or contradictory fields", t => {
+  t.deepEqual(validateApprovalEntry(BACKEND_CONTRACT_ENTRY), BACKEND_CONTRACT_ENTRY);
+  t.notThrows(() =>
+    validateApprovalEntry(
+      approval({
+        candidate_config_fingerprint: null,
+        candidate_summary: {
+          ...BACKEND_CONTRACT_ENTRY.candidate_summary,
+          prompt_bytes: 12_000,
+          prompt_codepoints: 8_000
+        },
+        created_by_account_id: null,
+        current_config_fingerprint: null,
+        current_summary: null,
+        entry_mode: "invite"
+      })
+    )
+  );
+  t.throws(() =>
+    validateCapabilityResponse({ bot_config_approval: { ...capability().bot_config_approval, extra: 1 } })
+  );
+  t.throws(() => validateApprovalEntry({ ...approval(), prompt: "must-never-arrive" }));
+  t.throws(() =>
+    validateApprovalEntry({ ...approved(), runtime_approved: true, current_config_fingerprint: FINGERPRINT_B })
+  );
+  t.throws(() =>
+    validateInventoryPage({
+      approvals: [{ ...approval(), current_summary: { ...approval().current_summary, prompt: "hidden" } }],
+      next_cursor: null,
+      protocol: 1
+    })
+  );
+  t.throws(() => validateApprovalEntry(approval({ updated_at: "1" })), { message: "invalid_audit_timestamp" });
+  t.throws(
+    () =>
+      validateInventoryPage({
+        approvals: Array.from({ length: 101 }, (_value, index) => approval({ hub_sid: `room-${index}` })),
+        next_cursor: null,
+        protocol: 1
+      }),
+    { message: "invalid_inventory_response" }
+  );
+});
+
+test("duplicate rooms and repeated cursors make the whole inventory unavailable", async t => {
+  let page = 0;
+  const duplicateClient = createClient(async () => {
+    page += 1;
+    return response({
+      approvals: [approval()],
+      next_cursor: page === 1 ? "10" : null,
+      protocol: 1
+    });
+  });
+  await t.throwsAsync(() => duplicateClient.listAll(), { message: "duplicate_inventory_hub" });
+
+  let cursorPage = 0;
+  const repeatedCursorClient = createClient(async () => {
+    cursorPage += 1;
+    return response({
+      approvals: [approval({ hub_sid: `room-${cursorPage}` })],
+      next_cursor: "10",
+      protocol: 1
+    });
+  });
+  await t.throwsAsync(() => repeatedCursorClient.listAll(), { message: "repeated_inventory_cursor" });
+
+  let descendingPage = 0;
+  const descendingCursorClient = createClient(async () => {
+    descendingPage += 1;
+    return response({
+      approvals: [approval({ hub_sid: `descending-room-${descendingPage}` })],
+      next_cursor: descendingPage === 1 ? "10" : "9",
+      protocol: 1
+    });
+  });
+  await t.throwsAsync(() => descendingCursorClient.listAll(), { message: "non_increasing_inventory_cursor" });
+});
+
+test("missing tokens and invalid path inputs fail before fetch", async t => {
+  let calls = 0;
+  const client = createBotConfigApprovalClient({
+    fetchImpl: async () => {
+      calls += 1;
+      return response({});
+    },
+    getToken: () => "",
+    buildUrl: path => path
+  });
+
+  await t.throwsAsync(() => client.listAll(), { message: "missing_auth_token" });
+  t.is(calls, 0);
+
+  const authenticated = createClient(async () => response({}));
+  await t.throwsAsync(() => authenticated.approve("../room", FINGERPRINT_A), { message: "invalid_hub_sid" });
+  await t.throwsAsync(() => authenticated.approve("room-a", "bad"), { message: "invalid_candidate_fingerprint" });
+});

--- a/test/unit/admin/bot-config-approvals-page.test.js
+++ b/test/unit/admin/bot-config-approvals-page.test.js
@@ -1,0 +1,431 @@
+/* eslint-disable react/prop-types */
+
+import test from "ava";
+
+require("../../../scripts/shim");
+
+const Module = require("module");
+const React = require("react");
+const { createRoot } = require("react-dom/client");
+const { act } = require("react-dom/test-utils");
+const { BotConfigApprovalApiError } = require("../../../admin/src/utils/bot-config-approvals-api");
+
+function withoutProps(props, names) {
+  const filtered = { ...props };
+  for (const name of names) delete filtered[name];
+  return filtered;
+}
+
+function elementStub(defaultElement, removedProps = []) {
+  return React.forwardRef(function ElementStub({ children, component: Component = defaultElement, ...props }, ref) {
+    return (
+      <Component ref={ref} {...withoutProps(props, removedProps)}>
+        {children}
+      </Component>
+    );
+  });
+}
+
+const ButtonStub = elementStub("button", ["color", "variant"]);
+const CardHeaderStub = ({ action, subheader, title, titleTypographyProps = {}, ...props }) => {
+  const { component: TitleComponent = "span", ...titleProps } = titleTypographyProps;
+  return (
+    <header {...props}>
+      <TitleComponent {...titleProps}>{title}</TitleComponent>
+      <p>{subheader}</p>
+      {action}
+    </header>
+  );
+};
+const ChipStub = ({ label, ...props }) => <span {...withoutProps(props, ["color"])}>{label}</span>;
+const CircularProgressStub = props => <span {...withoutProps(props, ["size"])} />;
+const DialogStub = ({ children, open, ...props }) =>
+  open ? (
+    <div role="dialog" {...withoutProps(props, ["onClose"])}>
+      {children}
+    </div>
+  ) : null;
+
+const moduleStubs = {
+  "@material-ui/core/Button": ButtonStub,
+  "@material-ui/core/Card": elementStub("div"),
+  "@material-ui/core/CardActions": elementStub("div"),
+  "@material-ui/core/CardContent": elementStub("div"),
+  "@material-ui/core/CardHeader": CardHeaderStub,
+  "@material-ui/core/Chip": ChipStub,
+  "@material-ui/core/CircularProgress": CircularProgressStub,
+  "@material-ui/core/Dialog": DialogStub,
+  "@material-ui/core/DialogActions": elementStub("div"),
+  "@material-ui/core/DialogContent": elementStub("div"),
+  "@material-ui/core/DialogContentText": elementStub("p"),
+  "@material-ui/core/DialogTitle": elementStub("h2"),
+  "@material-ui/core/Typography": elementStub("p", ["color", "gutterBottom", "variant"]),
+  "@material-ui/core/styles": { withStyles: () => Component => Component },
+  "../utils/with-common-styles": styles => styles,
+  "react-admin": { AUTH_ERROR: "AUTH_ERROR", Title: () => null }
+};
+
+const originalModuleLoad = Module._load;
+Module._load = function loadWithAdminStubs(request, parent, isMain) {
+  if (request === "react") return React;
+  if (Object.prototype.hasOwnProperty.call(moduleStubs, request)) return moduleStubs[request];
+  return originalModuleLoad.call(this, request, parent, isMain);
+};
+
+let BotConfigApprovalsComponent;
+try {
+  ({ BotConfigApprovalsComponent } = require("../../../admin/src/react-components/bot-config-approvals"));
+} finally {
+  Module._load = originalModuleLoad;
+}
+
+global.IS_REACT_ACT_ENVIRONMENT = true;
+
+const FINGERPRINT_A = `v1:${"a".repeat(64)}`;
+const FINGERPRINT_B = `v1:${"b".repeat(64)}`;
+const FINGERPRINT_C = `v1:${"c".repeat(64)}`;
+const classes = new Proxy({}, { get: (_target, key) => String(key) });
+
+function approval(overrides = {}) {
+  return {
+    approved_at: null,
+    approved_by_account_id: null,
+    approved_config_fingerprint: null,
+    candidate_config_fingerprint: FINGERPRINT_A,
+    candidate_summary: {
+      chat_enabled: true,
+      count: 2,
+      enabled: true,
+      mobility: "low",
+      prompt_bytes: 19,
+      prompt_codepoints: 17,
+      prompt_present: true
+    },
+    created_by_account_id: 7,
+    current_config_fingerprint: FINGERPRINT_B,
+    current_summary: {
+      chat_enabled: true,
+      count: 2,
+      enabled: false,
+      mobility: "low",
+      prompt_bytes: 19,
+      prompt_codepoints: 17,
+      prompt_present: true
+    },
+    entry_mode: "allow",
+    hub_sid: "room-a",
+    last_quarantine_reason: "legacy_migration",
+    last_quarantined_at: "2026-07-18T10:00:00.000Z",
+    last_quarantined_by_account_id: null,
+    runtime_approved: false,
+    state: "quarantined",
+    updated_at: "2026-07-18T10:00:00.000Z",
+    ...overrides
+  };
+}
+
+function approved(overrides = {}) {
+  return approval({
+    approved_at: "2026-07-18T11:00:00.000Z",
+    approved_by_account_id: 7,
+    approved_config_fingerprint: FINGERPRINT_A,
+    current_config_fingerprint: FINGERPRINT_A,
+    current_summary: {
+      chat_enabled: true,
+      count: 2,
+      enabled: true,
+      mobility: "low",
+      prompt_bytes: 19,
+      prompt_codepoints: 17,
+      prompt_present: true
+    },
+    last_quarantine_reason: "legacy_migration",
+    runtime_approved: true,
+    state: "approved",
+    ...overrides
+  });
+}
+
+async function flush(times = 1) {
+  for (let index = 0; index < times; index += 1) {
+    await act(async () => {
+      await new Promise(resolve => setTimeout(resolve, 0));
+    });
+  }
+}
+
+function buttonWithText(text) {
+  return [...document.querySelectorAll("button")].find(button => button.textContent.includes(text));
+}
+
+async function click(element) {
+  await act(async () => {
+    element.dispatchEvent(new window.MouseEvent("click", { bubbles: true }));
+  });
+}
+
+async function mount(apiClient, onAuthError = async () => {}) {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  await act(async () => {
+    root.render(<BotConfigApprovalsComponent classes={classes} apiClient={apiClient} onAuthError={onAuthError} />);
+  });
+  await flush(2);
+  return {
+    container,
+    async unmount() {
+      await act(async () => root.unmount());
+      container.remove();
+    }
+  };
+}
+
+test.serial(
+  "the page renders the final redacted summaries and blocks a legacy candidate without a fingerprint",
+  async t => {
+    const row = approval({
+      accidentally_returned_prompt: "secret-prompt-must-not-render",
+      candidate_config_fingerprint: null,
+      candidate_summary: {
+        ...approval().candidate_summary,
+        prompt_bytes: 12_000,
+        prompt_codepoints: 8_000
+      },
+      current_config_fingerprint: null,
+      current_summary: null
+    });
+    const apiClient = {
+      assertCapability: async () => {},
+      listAll: async () => [row],
+      approve: async () => {},
+      quarantine: async () => {}
+    };
+    const harness = await mount(apiClient);
+
+    t.true(document.body.textContent.includes("Inventario completo: 1 registro"));
+    t.true(document.body.textContent.includes("Presente (12000 bytes, 8000 caracteres Unicode)"));
+    t.true(document.body.textContent.includes("Sin configuración de bots"));
+    t.true(document.body.textContent.includes("Propietario: cuenta 7 · Acceso: Abierta"));
+    t.true(document.body.textContent.includes("Baja"));
+    t.false(document.body.textContent.includes("low"));
+    t.true(document.body.textContent.includes("no tiene un fingerprint verificable"));
+    t.false(document.body.textContent.includes("secret-prompt-must-not-render"));
+    t.true(buttonWithText("Aprobar candidato").disabled);
+    t.true(buttonWithText("Poner en cuarentena").disabled);
+    const article = document.querySelector("article");
+    const heading = document.getElementById("bot-config-approval-room-a");
+    t.truthy(article);
+    t.is(heading.tagName, "H2");
+    t.is(article.getAttribute("aria-labelledby"), heading.id);
+    t.falsy(document.querySelector("main"));
+    await harness.unmount();
+  }
+);
+
+test.serial("quarantine attribution distinguishes legacy, automatic, and recorded actors", async t => {
+  const apiClient = {
+    assertCapability: async () => {},
+    listAll: async () => [
+      approval(),
+      approval({ hub_sid: "room-b", last_quarantine_reason: "room_closed" }),
+      approval({
+        hub_sid: "room-c",
+        last_quarantine_reason: "bots_disabled",
+        last_quarantined_by_account_id: 42
+      })
+    ],
+    approve: async () => {},
+    quarantine: async () => {}
+  };
+  const harness = await mount(apiClient);
+
+  t.true(document.body.textContent.includes("Configuración heredada puesta en cuarentena; migración automática"));
+  t.true(document.body.textContent.includes("Sala cerrada; acción automática"));
+  t.false(document.body.textContent.includes("Sala cerrada; migración automática"));
+  t.true(document.body.textContent.includes("Bots deshabilitados; cuenta 42"));
+  await harness.unmount();
+});
+
+test.serial("approval confirms the captured fingerprint once and trusts only the durable reload", async t => {
+  const inventories = [[approval()], [approved()]];
+  const approveCalls = [];
+  let listCalls = 0;
+  const apiClient = {
+    assertCapability: async () => {},
+    listAll: async () => inventories[Math.min(listCalls++, inventories.length - 1)],
+    approve: async (...args) => {
+      approveCalls.push(args);
+      return { hub_sid: "room-a", status: "approved" };
+    },
+    quarantine: async () => {}
+  };
+  const harness = await mount(apiClient);
+
+  await click(buttonWithText("Aprobar candidato"));
+  t.true(document.body.textContent.includes("No es solo un cambio de etiqueta"));
+  t.true(document.body.textContent.includes(FINGERPRINT_A));
+  await click(buttonWithText("Aprobar este fingerprint"));
+  await flush(4);
+
+  t.is(approveCalls.length, 1);
+  t.is(approveCalls[0][0], "room-a");
+  t.is(approveCalls[0][1], FINGERPRINT_A);
+  t.is(listCalls, 2);
+  t.true(document.body.textContent.includes("Candidato aprobado con coincidencia durable exacta"));
+  t.true(document.body.textContent.includes("Aprobada"));
+  await harness.unmount();
+});
+
+test.serial("a durable match resolves an ambiguous action response without retrying", async t => {
+  const inventories = [[approval()], [approved()]];
+  let listCalls = 0;
+  let approveCalls = 0;
+  const apiClient = {
+    assertCapability: async () => {},
+    listAll: async () => inventories[Math.min(listCalls++, inventories.length - 1)],
+    approve: async () => {
+      approveCalls += 1;
+      throw new BotConfigApprovalApiError("network_error", { ambiguous: true });
+    },
+    quarantine: async () => {}
+  };
+  const harness = await mount(apiClient);
+
+  await click(buttonWithText("Aprobar candidato"));
+  await click(buttonWithText("Aprobar este fingerprint"));
+  await flush(4);
+
+  t.is(approveCalls, 1);
+  t.is(listCalls, 2);
+  t.true(document.body.textContent.includes("Candidato aprobado con coincidencia durable exacta"));
+  t.false(document.body.textContent.includes("No se pudo confirmar la respuesta"));
+  await harness.unmount();
+});
+
+test.serial("a stale 409 is never retried and replaces the reviewed row before another approval", async t => {
+  const changed = approval({ candidate_config_fingerprint: FINGERPRINT_C, updated_at: "2026-07-18T12:00:00.000Z" });
+  const inventories = [[approval()], [changed]];
+  let listCalls = 0;
+  let approveCalls = 0;
+  const apiClient = {
+    assertCapability: async () => {},
+    listAll: async () => inventories[Math.min(listCalls++, inventories.length - 1)],
+    approve: async () => {
+      approveCalls += 1;
+      throw new BotConfigApprovalApiError("fingerprint_mismatch", { status: 409 });
+    },
+    quarantine: async () => {}
+  };
+  const harness = await mount(apiClient);
+
+  await click(buttonWithText("Aprobar candidato"));
+  await click(buttonWithText("Aprobar este fingerprint"));
+  await flush(4);
+
+  t.is(approveCalls, 1);
+  t.is(listCalls, 2);
+  t.true(document.body.textContent.includes("La configuración cambió mientras la revisabas"));
+  t.true(document.body.textContent.includes(FINGERPRINT_C));
+  t.false(document.body.textContent.includes(FINGERPRINT_A));
+  await harness.unmount();
+});
+
+test.serial("quarantine is individual, confirmed, and observed from the durable inventory", async t => {
+  const inventories = [[approved()], [approval({ current_config_fingerprint: FINGERPRINT_B })]];
+  let listCalls = 0;
+  const quarantineCalls = [];
+  const apiClient = {
+    assertCapability: async () => {},
+    listAll: async () => inventories[Math.min(listCalls++, inventories.length - 1)],
+    approve: async () => {},
+    quarantine: async (...args) => {
+      quarantineCalls.push(args);
+      return { hub_sid: "room-a", status: "quarantined" };
+    }
+  };
+  const harness = await mount(apiClient);
+
+  await click(buttonWithText("Poner en cuarentena"));
+  t.true(document.body.textContent.includes("conserva el candidato"));
+  await click(buttonWithText("Confirmar cuarentena"));
+  await flush(4);
+
+  t.is(quarantineCalls.length, 1);
+  t.is(quarantineCalls[0][0], "room-a");
+  t.true(document.body.textContent.includes("Cuarentena durable confirmada"));
+  await harness.unmount();
+});
+
+test.serial("an authorization failure clears the page and delegates exactly one auth error", async t => {
+  const authStatuses = [];
+  const apiClient = {
+    assertCapability: async () => {
+      throw new BotConfigApprovalApiError("missing_auth_token", { status: 401 });
+    },
+    listAll: async () => [approval()],
+    approve: async () => {},
+    quarantine: async () => {}
+  };
+  const harness = await mount(apiClient, async status => authStatuses.push(status));
+
+  t.deepEqual(authStatuses, [401]);
+  t.true(document.body.textContent.includes("no tiene permisos de administración"));
+  t.false(document.body.textContent.includes("room-a"));
+  t.falsy(buttonWithText("Aprobar candidato"));
+  await harness.unmount();
+});
+
+test.serial("an action authorization failure delegates once and does not refetch with the rejected token", async t => {
+  const authStatuses = [];
+  let listCalls = 0;
+  let approveCalls = 0;
+  const apiClient = {
+    assertCapability: async () => {},
+    listAll: async () => {
+      listCalls += 1;
+      return [approval()];
+    },
+    approve: async () => {
+      approveCalls += 1;
+      throw new BotConfigApprovalApiError("forbidden", { status: 403 });
+    },
+    quarantine: async () => {}
+  };
+  const harness = await mount(apiClient, async status => authStatuses.push(status));
+
+  await click(buttonWithText("Aprobar candidato"));
+  await click(buttonWithText("Aprobar este fingerprint"));
+  await flush(2);
+
+  t.is(approveCalls, 1);
+  t.is(listCalls, 1);
+  t.deepEqual(authStatuses, [403]);
+  t.true(document.body.textContent.includes("no tiene permisos de administración"));
+  t.false(document.body.textContent.includes("room-a"));
+  t.falsy(buttonWithText("Aprobar candidato"));
+  await harness.unmount();
+});
+
+test.serial("unmount aborts a capability request and never proceeds to inventory", async t => {
+  let capabilitySignal;
+  let listCalls = 0;
+  const apiClient = {
+    assertCapability: ({ signal }) => {
+      capabilitySignal = signal;
+      return new Promise(() => {});
+    },
+    listAll: async () => {
+      listCalls += 1;
+      return [];
+    },
+    approve: async () => {},
+    quarantine: async () => {}
+  };
+  const harness = await mount(apiClient);
+
+  t.false(capabilitySignal.aborted);
+  await harness.unmount();
+  t.true(capabilitySignal.aborted);
+  t.is(listCalls, 0);
+});


### PR DESCRIPTION
## What\n- add the Spanish Admin route for bot configuration approvals\n- render only redacted configuration summaries and durable state\n- require individual confirmation for approve or quarantine actions\n- fail closed on auth, pagination, protocol, stale fingerprint, and ambiguous transport errors\n\n## Why\nAUD077 requires a deliberate human approval boundary before a bot configuration can run. The Admin UI consumes the exact backend protocol without exposing prompts or raw configuration.\n\n## Safety\n- no prompt/config payload rendering, persistence, or telemetry\n- one-shot POST actions with durable reload as the source of truth\n- clears stale inventory on authorization failure\n- blocks legacy and oversized candidates without an approvable fingerprint\n\n## Validation\n- 97 unit tests, 0 failures\n- Admin ESLint and HTMLHint\n- Admin production build\n- Prettier and git diff --check\n- Gitleaks on every changed and untracked file